### PR TITLE
fix(ci): update sam build command with correct template file path

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,7 @@ jobs:
           aws-region: ap-south-1
 
       - name: Build SAM Application
-        run: sam build
+        run: sam build --template infrastructure/template.yaml
 
       - name: Deploy with SAM to Staging
         run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --stack-name expense-tracker-staging --capabilities CAPABILITY_IAM


### PR DESCRIPTION
## Description
This PR fixes the CI build failure caused by the missing `template.yml` file error during the `sam build` step.  
The SAM build command has been updated to specify the correct relative path to the `template.yml` file.

## Fix Details
- Corrected the `sam build` command in the CI workflow to use the correct relative path for `template.yml`.
- Ensured the SAM CLI can locate the template file, preventing build errors.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?
- [x] Verified the CI workflow runs `sam build` successfully without errors.
- [x] Confirmed that the fix does not affect other pipeline steps or application functionality.

## Checklist

- [ ] My code follows the project's coding style guidelines
- [x] I have self-reviewed my code
- [ ] I have commented my code (where applicable)
- [ ] I have added tests (where applicable)
- [ ] All relevant documentation has been updated
- [x ] I have checked for merge conflicts