### PR TITLE
 Fix: Remove hardcoded AWS region from CI workflow(deploy-staging step)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
-          aws-region: ap-south-1
+          aws-region: ${{env.AWS_REGION_STAGING}}
 
       - name: Build SAM Application
         run: sam build --template infrastructure/template.yaml


### PR DESCRIPTION
## Problem
AWS region (`ap-south-1`) was hardcoded deploy-staging step in the GitHub Actions workflow. This reduced portability and required manual edits to change deployment regions.

## Solution/Changes
- Updated workflow to use `${{ env.AWS_REGION_STAGING }}` repository variable for region.
- Added/Verified `AWS_REGION_STAGING` is set in repository variables.
- All region-specific commands now reference the variable.

## Additional Notes
- This PR unblocks multi-region deployment flexibility for pipeline.
- No change to application code or SAM templates.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

---

## How Has This Been Tested?

<!-- Please describe how you tested your changes -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing steps
  - Manually triggered workflow to verify dynamic region selection.
  - Confirmed build/deploy steps pass for chosen region.

---

## Checklist
- [x] My code follows the project's coding style guidelines
- [x] I have self-reviewed my code
- [x] I have commented my code (where applicable)
- [x] I have added tests (where applicable)
- [x] All relevant documentation has been updated
- [x] I have checked for merge conflicts

---

## Related Issues
Fixes #60 
Closes #60