### PR TITLE
fix(ci): Correct aws-region environ variable call in deploy-staging step 

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
-          aws-region: ${{env.AWS_REGION_STAGING}}
+          aws-region: ${{vars.AWS_REGION_STAGING}}
 
       - name: Build SAM Application
         run: sam build --template infrastructure/template.yaml


### PR DESCRIPTION
## Error: 
Input required and not supplied: aws-region

## Description
- aws-region value could not be fetched from github environment variables
- AWS_REGION_STAGING github environment variable was incorrectly called using 'env' instead of 'vars'

## Solution Approach
- Rectified earlier call  using ${{env.AWS_REGION_STAGING}}  to ${{vars.AWS_REGION_STAGING}}

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have self-reviewed my code
- [x] I have commented my code (where applicable)
- [x] I have added tests (where applicable)
- [x] All relevant documentation has been updated
- [x] I have checked for merge conflicts

## Related Issues
Relates to #60