### PR TITLE
Implement Cognito user authentication in login handler (#69)

### DIFF
--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -45,8 +45,20 @@ def handler(event, _context):
     except ClientError as exc:
         error = exc.response.get("Error", {})
         code = error.get("Code", "ClientError")
-        message = error.get("Message", str(exc))
-        status = 401 if code in {"NotAuthorizedException", "UserNotFoundException"} else 500
+        # message = error.get("Message", str(exc))
+        # status = 401 if code in {"NotAuthorizedException", "UserNotFoundException"} else 500
+        # Default values
+        status = 500
+        message = "internal server error"
+
+        # Known auth failures → generic 401
+        if code in {"NotAuthorizedException", "UserNotFoundException"}:
+            status = 401
+            message = "incorrect username or password"
+        elif code == "UserNotConfirmedException":
+            status = 403
+            message = "user is not confirmed"
+
         return _response(status, {"errorCode": code, "message": message})
 
     auth = result.get("AuthenticationResult", {})

--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -31,12 +31,17 @@ def handler(event, _context):
     if not username or not password:
         return _response(400, {"message": "username and password are required"})
 
-    _cognito = boto3.client("cognito-idp", region_name=_REGION)
+    status, body = authenticate_user(username, password, _CLIENT_ID, _REGION)
+    return _response(status, body)
+
+
+def authenticate_user(username: str, password: str, client_id: str, region: str):
+    cognito = boto3.client("cognito-idp", region_name=region)
 
     try:
-        result = _cognito.initiate_auth(
+        result = cognito.initiate_auth(
             AuthFlow="USER_PASSWORD_AUTH",
-            ClientId=_CLIENT_ID,
+            ClientId=client_id,
             AuthParameters={
                 "USERNAME": username,
                 "PASSWORD": password,
@@ -45,13 +50,10 @@ def handler(event, _context):
     except ClientError as exc:
         error = exc.response.get("Error", {})
         code = error.get("Code", "ClientError")
-        # message = error.get("Message", str(exc))
-        # status = 401 if code in {"NotAuthorizedException", "UserNotFoundException"} else 500
-        # Default values
+
         status = 500
         message = "internal server error"
 
-        # Known auth failures → generic 401
         if code in {"NotAuthorizedException", "UserNotFoundException"}:
             status = 401
             message = "incorrect username or password"
@@ -59,14 +61,11 @@ def handler(event, _context):
             status = 403
             message = "user is not confirmed"
 
-        return _response(status, {"errorCode": code, "message": message})
+        return status, {"errorCode": code, "message": message}
 
     auth = result.get("AuthenticationResult", {})
-    return _response(
-        200,
-        {
-            "accessToken": auth.get("AccessToken"),
-            "idToken": auth.get("IdToken"),
-            "refreshToken": auth.get("RefreshToken"),
-        },
-    )
+    return 200, {
+        "accessToken": auth.get("AccessToken"),
+        "idToken": auth.get("IdToken"),
+        "refreshToken": auth.get("RefreshToken"),
+    }

--- a/tests/unit/auth/test_login.py
+++ b/tests/unit/auth/test_login.py
@@ -72,6 +72,54 @@ def test_login_bad_credentials_returns_401(mock_boto_client):
     assert resp["statusCode"] == 401
 
 
+@patch("boto3.client")
+def test_login_user_not_found_returns_401(mock_boto_client):
+    mock_cognito = MagicMock()
+    mock_boto_client.return_value = mock_cognito
+    mock_cognito.initiate_auth.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "UserNotFoundException",
+                "Message": "User does not exist.",
+            }
+        },
+        "InitiateAuth",
+    )
+
+    event = _event({"username": "nouser@example.com", "password": "Pass123!"})
+
+    resp = login.handler(event, None)
+
+    assert resp["statusCode"] == 401
+    body = json.loads(resp["body"])
+    # adjust to match your actual error message
+    assert body["message"] == "incorrect username or password"
+
+
+@patch("boto3.client")
+def test_login_unconfirmed_user_returns_403(mock_boto_client):
+    mock_cognito = MagicMock()
+    mock_boto_client.return_value = mock_cognito
+    mock_cognito.initiate_auth.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "UserNotConfirmedException",
+                "Message": "User is not confirmed.",
+            }
+        },
+        "InitiateAuth",
+    )
+
+    event = _event({"username": "user@example.com", "password": "Pass123!"})
+
+    resp = login.handler(event, None)
+
+    assert resp["statusCode"] == 403
+    body = json.loads(resp["body"])
+    assert body["message"] == "user is not confirmed"
+    assert body["errorCode"] == "UserNotConfirmedException"
+
+
 def test_login_with_apigw_proxy_event_shape():
     body = {"username": "user@example.com", "password": "Pass123!"}
     event = {


### PR DESCRIPTION
## Description
This PR implements the Cognito-based user authentication flow for the login handler and adds targeted unit tests for key auth failure scenarios. It completes all tasks in #69.

---

## Changes
- Parse and validate login request body (username/email and password).
- Call Cognito `InitiateAuth` with `USER_PASSWORD_AUTH` flow using the configured user pool client.
- Implement `authenticate_user()` helper to encapsulate Cognito `initiate_auth` logic.
- Normalize Cognito errors into consistent HTTP status codes and API messages:
  - `NotAuthorizedException` and `UserNotFoundException` → 401 + `"incorrect username or password"`.
  - `UserNotConfirmedException` → 403 + `"user is not confirmed"`.
  - All other `ClientError` values → 500 + `"internal server error"`.
- Return JWT tokens (`accessToken`, `idToken`, `refreshToken`) on successful authentication.
- Add unit tests for:
  - Successful authentication (returns tokens).
  - Invalid credentials (`NotAuthorizedException`) → 401.
  - User not found (`UserNotFoundException`) → 401 with generic message.
  - Unconfirmed user (`UserNotConfirmedException`) → 403.
  - Handling API Gateway proxy event shape.
---

## Type of Change

<!-- Check the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

---

## How Has This Been Tested?

<!-- Please describe how you tested your changes -->
- [x] Unit tests
  - `pytest tests/unit/auth/test_login.py`
- All tests pass with mocked Cognito client.
- [ ] Integration tests
- [ ] Manual testing steps

---

## Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have self-reviewed my code
- [x] I have commented my code (where applicable)
- [x] I have added tests (where applicable)
- [x] All relevant documentation has been updated
- [x] I have checked for merge conflicts

---

## Related Issues
Closes #69 

---

## Screenshots (not applicable)