### PR TITLE
Handle Cognito PasswordResetRequiredException in login (#70)

### DIFF
--- a/src/auth/login.py
+++ b/src/auth/login.py
@@ -60,6 +60,9 @@ def authenticate_user(username: str, password: str, client_id: str, region: str)
         elif code == "UserNotConfirmedException":
             status = 403
             message = "user is not confirmed"
+        elif code == "PasswordResetRequiredException":
+            status = 403
+            message = "password reset required"
 
         return status, {"errorCode": code, "message": message}
 

--- a/tests/unit/auth/test_login.py
+++ b/tests/unit/auth/test_login.py
@@ -120,6 +120,30 @@ def test_login_unconfirmed_user_returns_403(mock_boto_client):
     assert body["errorCode"] == "UserNotConfirmedException"
 
 
+@patch("boto3.client")
+def test_password_reset_required_returns_403(mock_boto_client):
+    mock_cognito = MagicMock()
+    mock_boto_client.return_value = mock_cognito
+    mock_cognito.initiate_auth.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "PasswordResetRequiredException",
+                "Message": "Password reset required.",
+            }
+        },
+        "InitiateAuth",
+    )
+
+    event = _event({"username": "user@example.com", "password": "oldpass"})
+
+    resp = login.handler(event, None)
+
+    assert resp["statusCode"] == 403
+    body = json.loads(resp["body"])
+    assert body["message"] == "password reset required"
+    assert body["errorCode"] == "PasswordResetRequiredException"
+
+
 def test_login_with_apigw_proxy_event_shape():
     body = {"username": "user@example.com", "password": "Pass123!"}
     event = {


### PR DESCRIPTION
## Description
This PR extends the login error handling to cover the `PasswordResetRequiredException` scenario from Cognito and adds unit test coverage, as part of the comprehensive error handling work in #70.

---
## Changes

- Update `authenticate_user()` in `src/auth/login.py` to:
  - Map `PasswordResetRequiredException` to HTTP 403.
  - Return a user-friendly message: `"password reset required"`.
- Ensure the login handler still returns a consistent JSON structure for errors:
  - `{"errorCode": "<CognitoErrorCode>", "message": "<human-friendly message>"}`.
- Add a unit test to `tests/unit/auth/test_login.py`:
  - Simulate `PasswordResetRequiredException` from `cognito-idp.initiate_auth`.
  - Assert:
    - `statusCode == 403`
    - `body["message"] == "password reset required"`
    - `body["errorCode"] == "PasswordResetRequiredException"`

---

## Rationale

- Aligns with Cognito’s documented `PasswordResetRequiredException` behavior while returning a clear, user-friendly HTTP 403 response. 
- Follows API error-handling best practices:
  - Appropriate 4xx status for client/action-required errors.
  - Consistent, structured error body with code + message. 

---

## Type of Change

<!-- Check the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

---

## How Has This Been Tested?
- Ran:
  - `pytest tests/unit/auth/test_login.py::test_password_reset_required_returns_403`
- All tests pass.

---

## Checklist

- [x] My code follows the project's coding style guidelines
- [x] I have self-reviewed my code
- [x] I have commented my code (where applicable)
- [x] I have added tests (where applicable)
- [ ] All relevant documentation has been updated
- [x] I have checked for merge conflicts

---

## Related Issues
Closes #70 

---

## Screenshots (not applicable)